### PR TITLE
Feature/instastart idenity field name

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion 25
     buildToolsVersion "25.0.0"
-
     defaultConfig {
         applicationId "com.layer.sdkquickstart"
         minSdkVersion 14
@@ -11,11 +10,18 @@ android {
         versionCode 1
         versionName "$versionCode"
     }
-
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+    productFlavors {
+        defaultConfig {
+
+        }
+        instaStart {
+
         }
     }
 }
@@ -24,11 +30,10 @@ dependencies {
     compile 'com.android.support:appcompat-v7:25.0.0'
     compile 'com.android.support:design:25.0.0'
     compile 'com.android.support:gridlayout-v7:25.0.0'
-
     // This includes Firebase Messaging. To remove push notification support add
     //    exclude group: 'com.google.firebase', module: 'firebase-messaging'
     //    exclude group: 'com.google.firebase', module: 'firebase-core'
-    compile ('com.layer.sdk:layer-sdk:0.23.3')
+    compile 'com.layer.sdk:layer-sdk:0.23.3'
     compile 'org.slf4j:slf4j-nop:1.5.8'
 }
 

--- a/app/src/main/java/com/layer/sdkquickstart/App.java
+++ b/app/src/main/java/com/layer/sdkquickstart/App.java
@@ -140,7 +140,14 @@ public class App extends Application {
 
     public static AuthenticationProvider getAuthenticationProvider() {
         if (sAuthProvider == null) {
-            sAuthProvider = new DefaultAuthenticationProvider(sInstance);
+            switch (BuildConfig.FLAVOR) {
+                case "instaStart":
+                    sAuthProvider = new InstastartAuthenticationProvider(sInstance);
+                case "defaultConfig":
+                    sAuthProvider = new DefaultAuthenticationProvider(sInstance);
+                default:
+                    sAuthProvider = new DefaultAuthenticationProvider(sInstance);
+            }
 
             // If we have cached credentials, try authenticating with Layer
             LayerClient layerClient = getLayerClient();

--- a/app/src/main/java/com/layer/sdkquickstart/App.java
+++ b/app/src/main/java/com/layer/sdkquickstart/App.java
@@ -143,8 +143,8 @@ public class App extends Application {
             switch (BuildConfig.FLAVOR) {
                 case "instaStart":
                     sAuthProvider = new InstastartAuthenticationProvider(sInstance);
+                    break;
                 case "defaultConfig":
-                    sAuthProvider = new DefaultAuthenticationProvider(sInstance);
                 default:
                     sAuthProvider = new DefaultAuthenticationProvider(sInstance);
             }

--- a/app/src/main/java/com/layer/sdkquickstart/InstastartAuthenticationProvider.java
+++ b/app/src/main/java/com/layer/sdkquickstart/InstastartAuthenticationProvider.java
@@ -1,0 +1,248 @@
+package com.layer.sdkquickstart;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.widget.Toast;
+
+import com.layer.sdk.LayerClient;
+import com.layer.sdk.exceptions.LayerException;
+import com.layer.sdkquickstart.util.AuthenticationProvider;
+import com.layer.sdkquickstart.util.CustomEnvironment;
+import com.layer.sdkquickstart.util.Log;
+
+import org.json.JSONObject;
+
+import java.io.BufferedInputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import static com.layer.sdkquickstart.util.Util.streamToString;
+
+/**
+ * Created by archit on 1/4/17.
+ */
+
+public class InstastartAuthenticationProvider implements AuthenticationProvider<InstastartAuthenticationProvider.Credentials> {
+    private static final String TAG = DefaultAuthenticationProvider.class.getSimpleName();
+
+    private final SharedPreferences mPreferences;
+    private AuthenticationProvider.Callback mCallback;
+
+    public InstastartAuthenticationProvider(Context context) {
+        mPreferences = context.getSharedPreferences(TAG, Context.MODE_PRIVATE);
+    }
+
+    @Override
+    public AuthenticationProvider<InstastartAuthenticationProvider.Credentials> setCredentials(InstastartAuthenticationProvider.Credentials credentials) {
+        replaceCredentials(credentials);
+        return this;
+    }
+
+    @Override
+    public boolean hasCredentials() {
+        return getCredentials() != null;
+    }
+
+    @Override
+    public AuthenticationProvider<InstastartAuthenticationProvider.Credentials> setCallback(AuthenticationProvider.Callback callback) {
+        mCallback = callback;
+        return this;
+    }
+
+    @Override
+    public void onAuthenticated(LayerClient layerClient, String userId) {
+        if (Log.isLoggable(Log.VERBOSE)) Log.v("Authenticated with Layer, user ID: " + userId);
+        layerClient.connect();
+        if (mCallback != null) mCallback.onSuccess(this, userId);
+    }
+
+    @Override
+    public void onDeauthenticated(LayerClient layerClient) {
+        if (Log.isLoggable(Log.VERBOSE)) Log.v("Deauthenticated with Layer");
+    }
+
+    @Override
+    public void onAuthenticationChallenge(LayerClient layerClient, String nonce) {
+        if (Log.isLoggable(Log.VERBOSE)) Log.v("Received challenge: " + nonce);
+        respondToChallenge(layerClient, nonce);
+    }
+
+    @Override
+    public void onAuthenticationError(LayerClient layerClient, LayerException e) {
+        String error = "Failed to authenticate with Layer: " + e.getMessage();
+        if (Log.isLoggable(Log.ERROR)) Log.e(error, e);
+        if (mCallback != null) mCallback.onError(this, error);
+    }
+
+    @Override
+    public boolean routeLogin(LayerClient layerClient, String layerAppId, Activity from) {
+        if ((layerClient != null) && layerClient.isAuthenticated()) {
+            // The LayerClient is authenticated: no action required.
+            if (Log.isLoggable(Log.VERBOSE)) Log.v("No authentication routing required");
+            return false;
+        }
+
+        if (layerAppId == null && !CustomEnvironment.hasEnvironments()) {
+            // With no Layer App ID (and no CustomEnvironment) we can't authenticate: bail out.
+            if (Log.isLoggable(Log.ERROR)) Log.v("No Layer App ID set");
+            Toast.makeText(from, R.string.app_id_required, Toast.LENGTH_LONG).show();
+            return true;
+        }
+
+        if ((layerClient != null) && hasCredentials()) {
+            // With a LayerClient and cached provider credentials, we can resume.
+            if (Log.isLoggable(Log.VERBOSE)) {
+                Log.v("Routing to resume Activity using cached credentials");
+            }
+            Intent intent = new Intent(from, ResumeActivity.class);
+            intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
+            intent.putExtra(ResumeActivity.EXTRA_LOGGED_IN_ACTIVITY_CLASS_NAME, from.getClass().getName());
+            intent.putExtra(ResumeActivity.EXTRA_LOGGED_OUT_ACTIVITY_CLASS_NAME, LoginActivity.class.getName());
+            from.startActivity(intent);
+            return true;
+        }
+
+        // We have a Layer App ID but no cached provider credentials: routing to Login required.
+        if (Log.isLoggable(Log.VERBOSE)) Log.v("Routing to login Activity");
+        Intent intent = new Intent(from, LoginActivity.class);
+        intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
+        from.startActivity(intent);
+        return true;
+    }
+
+    private void replaceCredentials(InstastartAuthenticationProvider.Credentials credentials) {
+        if (credentials == null) {
+            mPreferences.edit().clear().apply();
+            return;
+        }
+        mPreferences.edit()
+                .putString("appId", credentials.getLayerAppId())
+                .putString("email", credentials.getEmail())
+                .putString("password", credentials.getPassword())
+                .putString("authToken", credentials.getAuthToken())
+                .apply();
+    }
+
+    protected DefaultAuthenticationProvider.Credentials getCredentials() {
+        if (!mPreferences.contains("appId")) return null;
+        return new DefaultAuthenticationProvider.Credentials(
+                mPreferences.getString("appId", null),
+                mPreferences.getString("email", null),
+                mPreferences.getString("password", null),
+                mPreferences.getString("authToken", null));
+    }
+
+    private void respondToChallenge(LayerClient layerClient, String nonce) {
+        DefaultAuthenticationProvider.Credentials credentials = getCredentials();
+        if (credentials == null || credentials.getEmail() == null || (credentials.getPassword() == null && credentials.getAuthToken() == null) || credentials.getLayerAppId() == null) {
+            if (Log.isLoggable(Log.WARN)) {
+                Log.w("No stored credentials to respond to challenge with");
+            }
+            return;
+        }
+
+        try {
+            // Post request
+
+            String url = CustomEnvironment.getProviderUrl() + "/users/sign_in.json";
+            HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+            connection.setDoInput(true);
+            connection.setDoOutput(true);
+            connection.setRequestMethod("POST");
+            connection.setRequestProperty("Content-Type", "application/json");
+            connection.setRequestProperty("Accept", "application/json");
+            connection.setRequestProperty("X_LAYER_APP_ID", credentials.getLayerAppId());
+            if (credentials.getEmail() != null) {
+                connection.setRequestProperty("X_AUTH_EMAIL", credentials.getEmail());
+            }
+            if (credentials.getAuthToken() != null) {
+                connection.setRequestProperty("X_AUTH_TOKEN", credentials.getAuthToken());
+            }
+
+            // Credentials
+            JSONObject rootObject = new JSONObject();
+            JSONObject userObject = new JSONObject();
+            rootObject.put("user", userObject);
+            userObject.put("email", credentials.getEmail());
+            userObject.put("password", credentials.getPassword());
+            rootObject.put("nonce", nonce);
+
+            connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+
+            OutputStream os = connection.getOutputStream();
+            os.write(rootObject.toString().getBytes("UTF-8"));
+            os.close();
+
+            // Handle failure
+            int statusCode = connection.getResponseCode();
+            if (statusCode != HttpURLConnection.HTTP_OK && statusCode != HttpURLConnection.HTTP_CREATED) {
+                String error = String.format("Got status %d when requesting authentication for '%s' with nonce '%s' from '%s'",
+                        statusCode, credentials.getEmail(), nonce, url);
+                if (Log.isLoggable(Log.ERROR)) Log.e(error);
+                if (mCallback != null) mCallback.onError(this, error);
+                return;
+            }
+
+            // Parse response
+            InputStream in = new BufferedInputStream(connection.getInputStream());
+            String result = streamToString(in);
+            in.close();
+            connection.disconnect();
+            JSONObject json = new JSONObject(result);
+            if (json.has("error")) {
+                String error = json.getString("error");
+                if (Log.isLoggable(Log.ERROR)) Log.e(error);
+                if (mCallback != null) mCallback.onError(this, error);
+                return;
+            }
+
+            // Save provider's auth token and remove plain-text password.
+            String authToken = json.optString("authentication_token", null);
+            Credentials authedCredentials = new Credentials(credentials.getLayerAppId(), credentials.getEmail(), null, authToken);
+            replaceCredentials(authedCredentials);
+
+            // Answer authentication challenge.
+            String identityToken = json.optString("identity_token", null);
+            if (Log.isLoggable(Log.VERBOSE)) Log.v("Got identity token: " + identityToken);
+            layerClient.answerAuthenticationChallenge(identityToken);
+        } catch (Exception e) {
+            String error = "Error when authenticating with provider: " + e.getMessage();
+            if (Log.isLoggable(Log.ERROR)) Log.e(error, e);
+            if (mCallback != null) mCallback.onError(this, error);
+        }
+    }
+
+    public static class Credentials {
+        private final String mLayerAppId;
+        private final String mEmail;
+        private final String mPassword;
+        private final String mAuthToken;
+
+        public Credentials(String layerAppId, String email, String password, String authToken) {
+            mLayerAppId = layerAppId == null ? null : (layerAppId.contains("/") ? layerAppId.substring(layerAppId.lastIndexOf("/") + 1) : layerAppId);
+            mEmail = email;
+            mPassword = password;
+            mAuthToken = authToken;
+        }
+
+        public String getEmail() {
+            return mEmail;
+        }
+
+        public String getPassword() {
+            return mPassword;
+        }
+
+        public String getAuthToken() {
+            return mAuthToken;
+        }
+
+        public String getLayerAppId() {
+            return mLayerAppId;
+        }
+    }
+}

--- a/app/src/main/java/com/layer/sdkquickstart/LoginActivity.java
+++ b/app/src/main/java/com/layer/sdkquickstart/LoginActivity.java
@@ -14,8 +14,8 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.layer.sdkquickstart.conversationlist.ConversationsListActivity;
-import com.layer.sdkquickstart.util.CustomEnvironment;
 import com.layer.sdkquickstart.util.AuthenticationProvider;
+import com.layer.sdkquickstart.util.CustomEnvironment;
 import com.layer.sdkquickstart.util.Log;
 
 public class LoginActivity extends AppCompatActivity {
@@ -72,7 +72,7 @@ public class LoginActivity extends AppCompatActivity {
         final ProgressDialog progressDialog = new ProgressDialog(LoginActivity.this);
         progressDialog.setMessage(getResources().getString(R.string.login_dialog_message));
         progressDialog.show();
-        App.authenticate(new DefaultAuthenticationProvider.Credentials(App.getLayerAppId(), email, password, null),
+        App.authenticate(getCredentials(App.getLayerAppId(), email, password, null),
                 new AuthenticationProvider.Callback() {
                     @Override
                     public void onSuccess(AuthenticationProvider provider, String userId) {
@@ -101,5 +101,15 @@ public class LoginActivity extends AppCompatActivity {
                         });
                     }
                 });
+    }
+
+    private Object getCredentials(String appId, String email, String password, String authToken) {
+        switch (BuildConfig.FLAVOR) {
+            case "instaStart" :
+                return new InstastartAuthenticationProvider.Credentials(appId, email, password, authToken);
+            case "defaultConfig":
+            default:
+            return new DefaultAuthenticationProvider.Credentials(appId, email, password, authToken);
+        }
     }
 }


### PR DESCRIPTION
@smpete @feifanzhou this PR puts the field name change in its own auth provider (which is used in a separate product flavor) 

This way the project will continue to work for current quickstart users and can accommodate changes needed for Instastart  